### PR TITLE
Setting raven version to strictly use 0.10.0 only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/shiki/yii-sentry",
   "license": "MIT",
   "require": {
-    "raven/raven": ">=0.9.0"
+    "raven/raven": "0.10.0"
   },
   "autoload": {
     "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/shiki/yii-sentry",
   "license": "MIT",
   "require": {
-    "raven/raven": "0.10.0"
+    "raven/raven": ">=0.10.0"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
This PR will limit the raven version to use only 0.10.0.  Latest dev version of raven/raven has an issue in which one package can't be installed. See [issue](https://github.com/getsentry/raven-php/issues/218).
