### PR TITLE
Update raven version to use >=0.10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/shiki/yii-sentry",
   "license": "MIT",
   "require": {
-    "raven/raven": ">=0.9.0"
+    "raven/raven": "0.10.0"
   },
   "autoload": {
     "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/shiki/yii-sentry",
   "license": "MIT",
   "require": {
-    "raven/raven": "0.10.0"
+    "raven/raven": ">=0.10.0"
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
Issue earlier was caused by a deprecated composer in our CI server. My bad.
